### PR TITLE
Add an auth command.

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,13 +20,17 @@ $ go get -u github.com/joshbohde/lab
 $ go install github.com/joshbohde/lab/cmd/lab
 ```
 
-## Setup
-
-1. Visit https://gitlab.com/profile/personal_access_tokens and create a new access token with API Scope
-2. Run `git config --global lab.gitlab.com.token '<token>'`
-
-
 ## Commands
+
+### `auth`
+
+Will configure access tokens for the current project, if none exist.
+
+```
+$ lab auth
+```
+
+This will open your browser to your Gitlab access tokens page, for either https://gitlab.com, or your self-hosted instance. Create a new token with API scope, and paste it back into your terminal.
 
 ### `issue`
 

--- a/auth.go
+++ b/auth.go
@@ -1,0 +1,48 @@
+package lab
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/skratchdot/open-golang/open"
+)
+
+type AuthService struct {
+	Git Git
+}
+
+// AuthService will ensure the user logs in if the remote project requires it
+func (service *AuthService) RemoteProject() (RemoteProject, error) {
+	remote, err := service.Git.RemoteProject()
+
+	if missingToken, ok := err.(MissingToken); ok {
+		reader := bufio.NewReader(os.Stdin)
+
+		fmt.Printf("No access token for https://%s/ found. Please create a new access token with api scopes.\n", missingToken.Host)
+		fmt.Println("Press enter to open your browser to your access tokens page.")
+
+		reader.ReadString('\n')
+
+		err = open.Start(fmt.Sprintf("https://%s/profile/personal_access_tokens", missingToken.Host))
+		if err != nil {
+			fmt.Printf("Error trying open personal access token page.\n")
+			return remote, missingToken
+		}
+
+		if err != nil {
+			fmt.Printf("Error trying to read string.\n")
+			return remote, missingToken
+		}
+
+		fmt.Print("Please paste the access token here: ")
+
+		text, err := reader.ReadString('\n')
+
+		err = service.Git.SetAccessToken(remote, strings.Trim(text, "\n"))
+		return remote, err
+	}
+
+	return remote, err
+}

--- a/browser/browser.go
+++ b/browser/browser.go
@@ -1,0 +1,13 @@
+package browser
+
+import "github.com/skratchdot/open-golang/open"
+
+type Browser struct{}
+
+func New() *Browser {
+	return &Browser{}
+}
+
+func (b *Browser) Open(url string) error {
+	return open.Start(url)
+}

--- a/cmd/lab/auth.go
+++ b/cmd/lab/auth.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/joshbohde/lab"
+	"github.com/spf13/cobra"
+)
+
+var authService = lab.AuthService{
+	Git: gitService,
+}
+
+// mergeRequestCmd represents the mergeRequest command
+var authCmd = &cobra.Command{
+	Use:   "auth",
+	Short: "Authenticate on Gitlab",
+	Long:  ``,
+	Run: func(cmd *cobra.Command, args []string) {
+		remote, err := authService.RemoteProject()
+		if err != nil {
+			fmt.Printf("%s\n", err)
+			os.Exit(1)
+		} else {
+			fmt.Printf("Authenticated with %s\n", remote.Host)
+		}
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(authCmd)
+}

--- a/cmd/lab/auth.go
+++ b/cmd/lab/auth.go
@@ -9,7 +9,10 @@ import (
 )
 
 var authService = lab.AuthService{
-	Git: gitService,
+	Git:     gitService,
+	Browser: browserService,
+	Reader:  os.Stdin,
+	Writer:  os.Stdout,
 }
 
 // mergeRequestCmd represents the mergeRequest command

--- a/cmd/lab/issue.go
+++ b/cmd/lab/issue.go
@@ -12,6 +12,7 @@ var issueService = lab.IssueService{
 	Git:     gitService,
 	Gitlab:  gitlabService,
 	Message: messageService,
+	Writer:  os.Stdout,
 }
 
 var createIssueOptions = lab.CreateIssueOptions{}

--- a/cmd/lab/main.go
+++ b/cmd/lab/main.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/joshbohde/lab/browser"
 	git "github.com/joshbohde/lab/git"
 	"github.com/joshbohde/lab/gitlab"
 	"github.com/joshbohde/lab/message"
@@ -20,6 +21,7 @@ var (
 var gitService = git.New()
 var gitlabService = gitlab.New()
 var messageService = message.New()
+var browserService = browser.New()
 
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{

--- a/cmd/lab/merge_request.go
+++ b/cmd/lab/merge_request.go
@@ -12,6 +12,7 @@ var mergeRequestService = lab.MergeRequestService{
 	Git:     gitService,
 	Gitlab:  gitlabService,
 	Message: messageService,
+	Writer:  os.Stdout,
 }
 
 var createMergeRequestOptions = lab.CreateMergeRequestOptions{}

--- a/core.go
+++ b/core.go
@@ -1,8 +1,19 @@
 package lab
 
+import "fmt"
+
+type MissingToken struct {
+	Host string
+}
+
+func (m MissingToken) Error() string {
+	return fmt.Sprintf("no access token found for %s. create one by running `lab auth` in this directory.", m.Host)
+}
+
 type Git interface {
 	LocalBranch() (string, error)
 	RemoteProject() (RemoteProject, error)
+	SetAccessToken(RemoteProject, string) error
 }
 
 type Gitlab interface {

--- a/core.go
+++ b/core.go
@@ -33,3 +33,7 @@ type MessageOpts struct {
 type Message interface {
 	GetMessage(*string, MessageOpts) (func() error, error)
 }
+
+type Browser interface {
+	Open(string) error
+}

--- a/git/git.go
+++ b/git/git.go
@@ -43,13 +43,20 @@ func (g *Git) RemoteProject() (lab.RemoteProject, error) {
 	authToken, err := g.Get(fmt.Sprintf("lab.%s.token", r.Host))
 
 	if err != nil || authToken == "" {
-		err = fmt.Errorf("create an access token and configure it by running `git config --global lab.%s.token <token>`", r.Host)
+		err = lab.MissingToken{
+			Host: r.Host,
+		}
 		return r, err
 	}
 
 	r.Token = authToken
 	return r, nil
 
+}
+
+func (g *Git) SetAccessToken(r lab.RemoteProject, token string) error {
+	key := fmt.Sprintf("lab.%s.token", r.Host)
+	return g.Set(key, token, true)
 }
 
 func (g *Git) Get(key string) (string, error) {

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/mattn/go-colorable v0.0.9 // indirect
 	github.com/mattn/go-isatty v0.0.4 // indirect
 	github.com/mitchellh/go-homedir v1.0.0 // indirect
+	github.com/skratchdot/open-golang v0.0.0-20190104022628-a2dfa6d0dab6
 	github.com/spf13/cobra v0.0.3
 	github.com/spf13/pflag v1.0.3 // indirect
 	github.com/xanzy/go-gitlab v0.13.0

--- a/go.sum
+++ b/go.sum
@@ -23,6 +23,8 @@ github.com/mattn/go-isatty v0.0.4 h1:bnP0vzxcAdeI1zdubAl5PjU6zsERjGZb7raWodagDYs
 github.com/mattn/go-isatty v0.0.4/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNxMWT7Zi4=
 github.com/mitchellh/go-homedir v1.0.0 h1:vKb8ShqSby24Yrqr/yDYkuFz8d0WUjys40rvnGC8aR0=
 github.com/mitchellh/go-homedir v1.0.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
+github.com/skratchdot/open-golang v0.0.0-20190104022628-a2dfa6d0dab6 h1:cGT4dcuEyBwwu/v6tosyqcDp2yoIo/LwjMGixUvg3nU=
+github.com/skratchdot/open-golang v0.0.0-20190104022628-a2dfa6d0dab6/go.mod h1:sUM3LWHvSMaG192sy56D9F7CNvL7jUJVXoqM1QKLnog=
 github.com/spf13/cobra v0.0.3 h1:ZlrZ4XsMRm04Fr5pSFxBgfND2EBVa1nLpiy1stUsX/8=
 github.com/spf13/cobra v0.0.3/go.mod h1:1l0Ry5zgKvJasoi3XT1TypsSe7PqH0Sj9dhYf7v3XqQ=
 github.com/spf13/pflag v1.0.3 h1:zPAT6CGy6wXeQ7NtTnaTerfKOsV6V6F8agHXFiazDkg=

--- a/issue.go
+++ b/issue.go
@@ -3,6 +3,7 @@ package lab
 import (
 	"errors"
 	"fmt"
+	"io"
 )
 
 type Issue struct {
@@ -26,6 +27,7 @@ type IssueService struct {
 	Git     Git
 	Gitlab  Gitlab
 	Message Message
+	Writer  io.Writer
 }
 
 func (service *IssueService) Create(opts *CreateIssueOptions) error {
@@ -58,7 +60,7 @@ func (service *IssueService) Create(opts *CreateIssueOptions) error {
 		return err
 	}
 
-	fmt.Printf("%s\n", issue.URL)
+	fmt.Fprintf(service.Writer, "%s\n", issue.URL)
 
 	err = delete()
 

--- a/merge_requests.go
+++ b/merge_requests.go
@@ -3,6 +3,7 @@ package lab
 import (
 	"errors"
 	"fmt"
+	"io"
 )
 
 type MergeRequest struct {
@@ -37,6 +38,7 @@ type MergeRequestService struct {
 	Git     Git
 	Gitlab  Gitlab
 	Message Message
+	Writer  io.Writer
 }
 
 func (service *MergeRequestService) Create(opts *CreateMergeRequestOptions) error {
@@ -86,7 +88,7 @@ func (service *MergeRequestService) Create(opts *CreateMergeRequestOptions) erro
 		return err
 	}
 
-	fmt.Printf("%s\n", mr.URL)
+	fmt.Fprintf(service.Writer, "%s\n", mr.URL)
 
 	err = delete()
 


### PR DESCRIPTION
Running `lab` auth will now open the user's browser to the access
tokens page, allowing them to create a new token.